### PR TITLE
Added data control to the fetch operations

### DIFF
--- a/FACCookbook/AppDelegate.m
+++ b/FACCookbook/AppDelegate.m
@@ -19,17 +19,11 @@
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
 
     // XXX: For Development only. Must be updated to only get latest for Location and Recipes
-    [[DataService sharedInstance] fetchRecipeData];
-    [[DataService sharedInstance] fetchLocationData];
-    [[DataService sharedInstance] fetchPopularData];
-    [[DataService sharedInstance] fetchPurchasedData];
-    [[DataService sharedInstance] fetchFeaturedData];
+    [[DataService sharedInstance] fetchData];
     // Override point for customization after application launch.
 
-    
-  
-  UIColor *themeColor = [UIColor colorWithRed:0.01f green:0.41f blue:0.22f alpha:1.0f];
-  self.window.tintColor = themeColor;
+    UIColor *themeColor = [UIColor colorWithRed:0.01f green:0.41f blue:0.22f alpha:1.0f];
+    self.window.tintColor = themeColor;
     return YES;
 }
 
@@ -48,15 +42,6 @@
 }
 
 - (void)applicationDidBecomeActive:(UIApplication *)application {
-    // XXX: For Development only. Must be updated to only get latest for Location and Recipes
-    /*
-    [[DataService sharedInstance] fetchRecipeData];
-    [[DataService sharedInstance] fetchLocationData];
-    [[DataService sharedInstance] fetchPopularData];
-    [[DataService sharedInstance] fetchPurchasedData];
-    [[DataService sharedInstance] fetchFeaturedData];
-
-*/
     // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
 }
 

--- a/FACCookbook/DataService.h
+++ b/FACCookbook/DataService.h
@@ -12,11 +12,8 @@
 @interface DataService : NSObject
 
 + (instancetype)sharedInstance;
-- (void)fetchRecipeData;
-- (void)fetchLocationData;
-- (void)fetchFeaturedData;
-- (void)fetchPopularData;
-- (void)fetchPurchasedData;
+- (void)fetchData;
+
 - (Recipe*) loadRecipeFromCoreData:(NSNumber*)recipeId;
 - (NSArray*)loadRecipeFromCoreData;
 @end


### PR DESCRIPTION
Adds fetch operations to a single file queue. Slightly slower admittedly but provides easy gating of data integrity.

This will allow us to keep the user defaults in sync, without introducing complicated dispatch/threading models.

This will be required to ensure that we are using the correct `lastUpdated` time whenever we fetch data from the server.
### TODO:

Need to add data validation to the processors. This will be done in the next PR
